### PR TITLE
Mark PyJWT dependency as optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
     scripts=['canister.py'],
     install_requires=[
         'bottle',
-        'PyJWT'
     ],
+    extras_require={
+        'jwt': ['PyJWT'],
+    },
 )


### PR DESCRIPTION
This one ensures `JWT` support is optional, since not everyone needs it and instead might wanted to avoid enforced installation of extra dependencies.