### PR TITLE
Fix subtle bug with session data initialization

### DIFF
--- a/canister.py
+++ b/canister.py
@@ -187,9 +187,11 @@ class SessionCache:
             self._cache[sid] = (user, data)
             
     
-    def create(self, user=None, data={}):
+    def create(self, user=None, data=None):
         sid = base64.b64encode(os.urandom(18)).decode('ascii')
         with self._lock:
+            if not data:
+                data = {}
             self._cache[sid] = (user, data)
         
         return (sid, user, data)


### PR DESCRIPTION
Canister had a bug where session data was shared across sessions (i.e. if you set something in `session.data` in session A, it is also set for session B). This stemmed from the `create()` method in the `SessionCache` class, which used an empty dictionary as the default value for the data argument when creating a new session. Python has annoying semantics regarding mutable objects as default values (http://effbot.org/zone/default-values.htm), and thus this method used the *same* dictionary for *all* data objects across sessions.

This simple change preserves the semantics of the original method while fixing the bug to ensure that data across sessions remains separate.