### PR TITLE
Add a way to completely disable Canister logging handler

### DIFF
--- a/canister.py
+++ b/canister.py
@@ -76,16 +76,17 @@ def _buildLogger(config):
     if level == 'DISABLED':
         return log
         
-    if not path:
-        h = logging.StreamHandler()
-    else:
-        os.makedirs(path, exist_ok=True)
-        h = logging.handlers.TimedRotatingFileHandler( os.path.join(path, 'log'), when='midnight', backupCount=int(days))
-    
     log.setLevel(level)
-    f = logging.Formatter('%(asctime)s %(levelname)-8s [%(threadName)s]   %(message)s')
-    h.setFormatter( f )
-    log.addHandler( h )
+    if path is not False:
+        if not path:
+            h = logging.StreamHandler()
+        else:
+            os.makedirs(path, exist_ok=True)
+            h = logging.handlers.TimedRotatingFileHandler( os.path.join(path, 'log'), when='midnight', backupCount=int(days))
+        
+        f = logging.Formatter('%(asctime)s %(levelname)-8s [%(threadName)s]   %(message)s')
+        h.setFormatter( f )
+        log.addHandler( h )
     
     return log
 


### PR DESCRIPTION
Hi,

I needed a way to have logging in Canister, but nothing else. When setting `path` to `None`, there is a `StreamHandler` logging handler added to the canister logger, resulting in double output (each line is printed twice, once with the default handler and once with the added stream handler).

Not sure this is the best way of dealing with it, but so far it does the trick. Let me know what you think about it.

Thanks!